### PR TITLE
Fixed two-way clustering using GaneSH.

### DIFF
--- a/LemonTree/src/lemontree/ganesh/GibbsSampler.java
+++ b/LemonTree/src/lemontree/ganesh/GibbsSampler.java
@@ -167,11 +167,17 @@ public class GibbsSampler {
 		}
 		loglike = loglikelihoodsum();
 		// merge clusters
-		for (int m = 0; m < ClusterSet.size(); m++) {
+    int j = 0;
+    int total = ClusterSet.size();
+		for (int m = 0; m < total; m++) {
 			for (int k = 0; k < ClusterSet.size(); k++) {
 				ClusterSet.get(k).number = k;
 			}
-			this.operationCluster(ClusterSet.get(m));
+			if (!this.operationCluster(ClusterSet.get(j))) {
+        // the cluster was not removed
+        // move the pointer forward
+        j++;
+      }
 		}
 		loglike = loglikelihoodsum();
 		return (loglike);
@@ -187,11 +193,17 @@ public class GibbsSampler {
 		do {
 			large = loglike;
 		//	count += 1;
-			for (int m = 0; m < ClusterSet.size(); m++) {
+      int j = 0;
+      int total = ClusterSet.size();
+			for (int m = 0; m < total; m++) {
 				for (int k = 0; k < ClusterSet.size(); k++) {
 					ClusterSet.get(k).number = k;
 				}
-				this.operationCluster(ClusterSet.get(m));
+				if (!this.operationCluster(ClusterSet.get(j))) {
+          // the cluster was not removed
+          // move the pointer forward
+          j++;
+        }
 			}
 			loglike = loglikelihoodsum();
 		} while (Math.abs(large - loglike) > epsConv * row * column);
@@ -459,7 +471,7 @@ public class GibbsSampler {
 	 * 
 	 * @param clust cluster to be moved.
 	 */
-	public void operationCluster(Cluster clust) {
+	public boolean operationCluster(Cluster clust) {
 		DoubleMatrix1D ratio = new DenseDoubleMatrix1D(ClusterSet.size());
 		// create a vector of probability of merging given cluster with evry
 		// other
@@ -481,7 +493,9 @@ public class GibbsSampler {
 				ClusterSet.get(outcome).RowSet.add(row);
 			ClusterSet.remove(clust.number);
 			num_cluster = num_cluster - 1;
+      return true;
 		}
+    return false;
 	}
 
 	/**

--- a/LemonTree/src/lemontree/modulenetwork/TreeNode.java
+++ b/LemonTree/src/lemontree/modulenetwork/TreeNode.java
@@ -879,10 +879,16 @@ public class TreeNode implements Comparable {
         	this.testSplitsRandom = new ArrayList<Split>(numRegAssign);
         	ArrayList<Split> regulatorSplits = this.computeRegulatorSplitsBayes(regulators, beta);
         	ArrayList<Double> regulatorSplitProbs = new ArrayList<Double>(regulatorSplits.size());
-        	// fill regulatorSplitProbs with weights, compute normalization along the way
-        	double probnorm = 0.0;
+          double maxRegulatorScore = Double.NEGATIVE_INFINITY;
+          for (Split splt : regulatorSplits){
+            if (maxRegulatorScore < splt.regulatorScore) {
+              maxRegulatorScore = splt.regulatorScore;
+            }
+        	}
+          // fill regulatorSplitProbs with weights, compute normalization along the way
+          double probnorm = 0.0;
         	for (Split splt : regulatorSplits){
-        		double weight = Math.exp(splt.regulatorScore);
+        		double weight = Math.exp(splt.regulatorScore - maxRegulatorScore);
         		probnorm += weight;
         		regulatorSplitProbs.add(weight);
         	}


### PR DESCRIPTION
I was testing the `ganesh` task and found that not all clusters were getting considered for merging during the two-way clustering. More specifically, I found the following two issues in the function `Cluster` of `class GibbsSampler` that were causing the for-loop that calls `operationCluster` to skip some clusters:
1. The loop-variable `m` is bounded by `ClusterSet.size()`. However, `ClusterSet.size()` changes whenever a cluster is deleted by the call to `operationCluster`. Therefore, the loop is executed fewer times than the number of clusters, thus skipping some clusters at the end.
2. The loop-variable is also used for getting the cluster to be considered for merging by calling `ClusterSet.get(m)`. However, if a cluster is deleted, then the index of the remaining clusters in `ClusterSet` gets subtracted by one. Therefore, using `m` to index into `ClusterSet`, the clusters next to the deleted clusters are also skipped.

Although, I did not test it specifically, these issues seem to exist in the `clusterClusters` function as well.

I have made these changes for fixing the aforementioned issues in both `Cluster` as well as `clusterClusters`. Please review these and let me know if any further changes are required.