### PR TITLE
Fixed the issue of low scores leading to zero weights in TreeNode::findRegulatorBayesStoch

### DIFF
--- a/LemonTree/src/lemontree/modulenetwork/TreeNode.java
+++ b/LemonTree/src/lemontree/modulenetwork/TreeNode.java
@@ -879,10 +879,16 @@ public class TreeNode implements Comparable {
         	this.testSplitsRandom = new ArrayList<Split>(numRegAssign);
         	ArrayList<Split> regulatorSplits = this.computeRegulatorSplitsBayes(regulators, beta);
         	ArrayList<Double> regulatorSplitProbs = new ArrayList<Double>(regulatorSplits.size());
-        	// fill regulatorSplitProbs with weights, compute normalization along the way
-        	double probnorm = 0.0;
+          double maxRegulatorScore = Double.NEGATIVE_INFINITY;
+          for (Split splt : regulatorSplits){
+            if (maxRegulatorScore < splt.regulatorScore) {
+              maxRegulatorScore = splt.regulatorScore;
+            }
+        	}
+          // fill regulatorSplitProbs with weights, compute normalization along the way
+          double probnorm = 0.0;
         	for (Split splt : regulatorSplits){
-        		double weight = Math.exp(splt.regulatorScore);
+        		double weight = Math.exp(splt.regulatorScore - maxRegulatorScore);
         		probnorm += weight;
         		regulatorSplitProbs.add(weight);
         	}


### PR DESCRIPTION
While experimenting with the `regulators` task, I noticed that in the function `TreeNode::findRegulatorBayesStoch` weights for all the splits were zero. This was because all the split scores being too low. I fixed this issue by scaling the exponential weighting of the split scores, similar to how it is handled in the function [`GibbsSampler::operation`](https://github.com/erbon7/lemon-tree/blob/f683df2609230acfeb6306f37322ea598f6159fe/LemonTree/src/lemontree/ganesh/GibbsSampler.java#L372), etc.

Please review this change and let me know if any edits are required.